### PR TITLE
Bugfix in `pip install` logic in `setup`

### DIFF
--- a/src/setup
+++ b/src/setup
@@ -272,7 +272,7 @@ pip_install() {
   msg Installing pip packages into environment: $name
   (
     conda_activate $name
-    pip install $@ | grep -v "^Requirement already satisfied: .*$"
+    pip install $@ | { grep -v "already satisfied" || true; }
   )
 }
 


### PR DESCRIPTION
## Description:

Resolves #92.

The `setup` script is designed so that it can be updated and re-run to bring the conda installations and environments up-to-date without forcing a complete reinstallation. For example, if a change appears on `main` that calls for a new version of the `anemoi-training` package, and that change is merged into one's git clone, `setup` (potentially via `make env`) can be called again to update the existing conda environments.

However, the old `pip install` command would fail if the `grep -v` component filtered _all_ lines from pip's output, which would happen if the pip packages were already fully up-to-date.

## Type of change:

- [x] Bug fix

## Area(s) affected

- [ ] Other: software environment creation/update

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary

## Testing / Verification:

Manually tested `make env` with and without the change to verify that the bug was present without and absent with the fix.
