### PR TITLE
Add `--override-channels` to conda commands

### DIFF
--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -52,7 +52,7 @@ inference:
       - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
     executable: eagle-tools inference inference.yaml
   rundir: '{{ app.rundir }}/inference'
-platform: !dict '{{ app.platform }}'
+platform: *platform
 prewxvx:
   common:
     execution: &prewxvx-common-execution
@@ -93,7 +93,7 @@ prewxvx:
             method: 'conservative_normed'
           target_grid_path: '{{ val.data.rundir }}/{{ val.filenames.gfs_target_grid }}'
       rundir: '{{ val.vx.rundir }}/prewxvx/{{ prewxvx.global.prewxvx.name }}'
-    platform: !dict '{{ app.platform }}'
+    platform: *platform
   lam:
     prewxvx:
       execution:
@@ -105,7 +105,7 @@ prewxvx:
         output_path: '{{ val.vx.rundir }}/postprocessed_files/{{ prewxvx.lam.prewxvx.name }}'
         model_type: nested-lam
       rundir: '{{ val.vx.rundir }}/prewxvx/{{ prewxvx.lam.prewxvx.name }}'
-    platform: !dict '{{ app.platform }}'
+    platform: *platform
 training:
   anemoi:
     defaults:
@@ -230,7 +230,7 @@ training:
           save_dir: ${system.output.logs.mlflow}
         wandb:
           enabled: false
-          entity: null+
+          entity: null+         
           _target_: pytorch_lightning.loggers.wandb.WandbLogger
           offline: False
           log_model: False
@@ -309,7 +309,7 @@ training:
         data:
           node_builder:
             _target_: anemoi.graphs.nodes.AnemoiDatasetNodes
-            dataset: ${dataloader.training.datasets.data.dataset_config}
+            dataset:  ${dataloader.training.datasets.data.dataset_config}
           attributes: ${graph.attributes.nodes}
         hidden:
           node_builder:
@@ -318,24 +318,24 @@ training:
             lat_key: lat
             lon_key: lon
       edges:
-        # Encoder
-        - source_name: data
-          target_name: hidden
-          edge_builders:
-            - _target_: anemoi.graphs.edges.KNNEdges
-              num_nearest_neighbours: 12
-              source_mask_attr_name: null
-              target_mask_attr_name: null
-          attributes: ${graph.attributes.edges}
-        # Decoder
-        - source_name: hidden
-          target_name: data
-          edge_builders:
-            - _target_: anemoi.graphs.edges.KNNEdges
-              num_nearest_neighbours: 3
-              source_mask_attr_name: null
-              target_mask_attr_name: null
-          attributes: ${graph.attributes.edges}
+      # Encoder
+      - source_name: data
+        target_name: hidden
+        edge_builders:
+        - _target_: anemoi.graphs.edges.KNNEdges
+          num_nearest_neighbours: 12
+          source_mask_attr_name: null
+          target_mask_attr_name: null
+        attributes: ${graph.attributes.edges}
+      # Decoder
+      - source_name: hidden
+        target_name: data
+        edge_builders:
+        - _target_: anemoi.graphs.edges.KNNEdges
+          num_nearest_neighbours: 3
+          source_mask_attr_name: null
+          target_mask_attr_name: null
+        attributes: ${graph.attributes.edges}
       attributes:
         nodes:
           # Attributes for data nodes
@@ -630,7 +630,7 @@ vx:
           name: v_10m
   grid2grid:
     global:
-      platform: !dict '{{ app.platform }}'
+      platform: *platform
       wxvx: # config for the EAGLE driver
         execution:
           batchargs:
@@ -660,7 +660,7 @@ vx:
             method: NEAREST
             to: forecast
     lam:
-      platform: !dict '{{ app.platform }}'
+      platform: *platform
       wxvx: # config for the EAGLE driver
         execution:
           batchargs:
@@ -695,7 +695,7 @@ vx:
           regrid: !dict '{{ vx.grid2grid.global.wxvx.wxvx.regrid }}'
   grid2obs:
     global:
-      platform: !dict '{{ app.platform }}'
+      platform: *platform
       wxvx: # config for the EAGLE driver
         execution:
           batchargs:
@@ -723,7 +723,7 @@ vx:
             method: BILIN
             to: G104
     lam:
-      platform: !dict '{{ app.platform }}'
+      platform: *platform
       wxvx: # config for the EAGLE driver
         execution:
           batchargs:
@@ -778,7 +778,7 @@ zarrs:
             regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_719x1440_180x360.nc") }}'
             target_grid_path: '{{ val.data.rundir}}/{{ val.filenames.gfs_target_grid }}'
       rundir: '{{ val.data.rundir }}'
-    platform: !dict '{{ app.platform }}'
+    platform: *platform
   hrrr:
     zarr:
       execution:
@@ -803,4 +803,4 @@ zarrs:
             regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_1059x1799_211x359.nc") }}'
             target_grid_path: '{{ val.data.rundir }}/{{ val.filenames.hrrr_target_grid }}'
       rundir: '{{ val.data.rundir }}'
-    platform: !dict '{{ app.platform }}'
+    platform: *platform


### PR DESCRIPTION
This will prevent the license-restricted Anaconda `default` / `main` channels from being used, even if specified in a user's `~/.condarc` file.