### PR TITLE
Trigger nested EAGLE CI on PR updates

### DIFF
--- a/.github/workflows/nested_eagle.yml
+++ b/.github/workflows/nested_eagle.yml
@@ -2,7 +2,7 @@ name: Nested Eagle CI Pipeline (uwtools)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 concurrency:
   group: nested-eagle-ci-${{ github.event.pull_request.number }}
@@ -19,10 +19,13 @@ jobs:
     if: >-
       ${{
         !github.event.pull_request.draft &&
+        contains(github.event.pull_request.labels.*.name, 'eagle-ursa') &&
         !contains(github.event.pull_request.labels.*.name, 'ci-running')
       }}
     runs-on: ursa
     timeout-minutes: 1440
+    environment:
+      name: eagle-ursa
 
     steps:
       - name: Checkout PR head
@@ -66,6 +69,7 @@ jobs:
           exit 0
 
       - name: Add ci-running label
+        continue-on-error: true
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: ci-running
@@ -236,6 +240,7 @@ jobs:
     needs: [run_pipeline]
     steps:
       - name: Remove ci-running label
+        continue-on-error: true
         uses: mondeja/remove-labels-gh-action@v2.0.0
         with:
           labels: "ci-running"

--- a/.github/workflows/nested_eagle.yml
+++ b/.github/workflows/nested_eagle.yml
@@ -18,7 +18,6 @@ jobs:
     name: Run Nested EAGLE end-to-end on Ursa
     if: >-
       ${{
-        !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'eagle-ursa') &&
         !contains(github.event.pull_request.labels.*.name, 'ci-running')
       }}

--- a/.github/workflows/nested_eagle.yml
+++ b/.github/workflows/nested_eagle.yml
@@ -1,8 +1,8 @@
 name: Nested Eagle CI Pipeline (uwtools)
 
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: nested-eagle-ci-${{ github.event.pull_request.number }}
@@ -18,7 +18,7 @@ jobs:
     name: Run Nested EAGLE end-to-end on Ursa
     if: >-
       ${{
-        github.event.review.state == 'approved' &&
+        !github.event.pull_request.draft &&
         !contains(github.event.pull_request.labels.*.name, 'ci-running')
       }}
     runs-on: ursa


### PR DESCRIPTION
<!-- INSTRUCTIONS: 
- READ/FOLLOW THE DIRECTIONS IN EACH SECTION
- Complete the 'Commit Requirements' below
- Use GitHub markup as much as possible (https://docs.github.com/en/get-started/writing-on-github)
- Leave your PR in a draft state until all underlying work is completed.
-->

## Description:
<!-- This description will become the commit message for the PR. -->
<!-- See https://cbea.ms/git-commit for commit message suggestions. -->
<!--
Provide a clear and concise description of *what* this PR does and *why*.
Explain why this change is needed and any context that helps reviewers.
Add the related GitHub Issues here.
Please be sure to add the issue this PR resolves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EPIC/repo#5678
-->
Update nested EAGLE CI to trigger on PR updates instead of review submissions.
## Type of change:
<!--
Indicate PR type of change.
Delete options that are not applicable. 
-->

- switched the workflow trigger from `pull_request_review` to `pull_request`
- updated trigger types to:
  - `opened`
  - `synchronize`
  - `reopened`
  - `ready_for_review`
- removed the dependency on `github.event.review.state == 'approved'`


## Area(s) affected
<!-- Check all that apply -->
- [ ] nested_eagle workflow
- [ ] Verification / evaluation (via WXVX)
- [ ] Data prep / UFS2ARCO
- [ ] Config (YAML)
- [ ] Plotting / post-processing
- [ ] Infrastructure / Slurm scripts
- [ ] Other:

## Commit Requirements:
<!--
- Check off completed items. Use [X] for a filled in checkbox or leave it [ ] for an empty checkbox
- Your pull request (PR) will not be considered until all requirements are met.
- THIS IS YOUR RESPONSIBILITY
-->
- [ ] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [ ] Fill out all sections of this template.
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the system documentation if necessary

## Testing / Verification:
<!--
Provide minimal reproducible steps and results.
Include configs, commands, and expected outputs where possible.
Delete this section if not applicable.
-->
- [ ] I ran and/or verified the changes (or provided a test plan)
- Commands/config used:
  - 
- Evidence (logs, key output paths, screenshots if relevant):
  - 

## Runtime Environment:
<!--
Fill in if you ran on HPC or a specific system. Delete if not applicable.
-->
- System/HPC:
- Account/role:
- Conda env:
- Key versions (optional):
  - `python --version`:
  - `wxvx --version` (if applicable):
  - MET version (if applicable):

## Commit Message:
<!--
Provide a concise commit message for any subcomponents; delete unnecessary info.
-->
* UFS2ARCO -
* WXVX (verification) -

## Subcomponent Pull Requests:
<!--
Provide a list of NOAA-EPIC/EAGLE and subcomponents involved with this PR and include links to subcomponent PRs.
Example:
* EAGLE: NOAA-EPIC/EAGLE#13
* UFS2ARCO: NOAA-PSL/UFS2ARCO#734
* WXVX: NOAA-EPIC/WXVX#33
Delete sections that are not needed.
-->
* EAGLE: NOAA-EPIC/EAGLE#
* UFS2ARCO: NOAA-PSL/UFS2ARCO#
* WXVX (verification): NOAA-EPIC/WXVX#
* None

