### PR TITLE
Update conda environments

### DIFF
--- a/src/envs/base.yaml
+++ b/src/envs/base.yaml
@@ -3,5 +3,4 @@ channels:
   - conda-forge
   - ufs-community
 dependencies:
-  - pip
   - uwtools 2.14.*

--- a/src/envs/data.yaml
+++ b/src/envs/data.yaml
@@ -8,6 +8,7 @@ dependencies:
   - mpi4py 4.1.*
   - numpy 1.26.4
   - pandas 2.3.3
+  - pip
   - setuptools 81.0.*
   - types-pyyaml
   - ufs2arco 0.19.*

--- a/src/envs/inference.yaml
+++ b/src/envs/inference.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - flash-attn 2.8.*
   - numpy 2.2.6.*
+  - pip
   - python 3.12
   - uwtools 2.14.*
   - pip:

--- a/src/envs/training.yaml
+++ b/src/envs/training.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - flash-attn 2.8.*
   - numpy 1.26.4.*
+  - pip
   - python 3.12
   - setuptools 81.0.*
   - uwtools 2.14.*

--- a/src/envs/visualization.yaml
+++ b/src/envs/visualization.yaml
@@ -6,6 +6,7 @@ dependencies:
   - cartopy 0.25.*
   - matplotlib 3.10.*
   - numpy 2.2.6
+  - pip
   - python 3.13
   - uwtools 2.14.*
   - xarray 2026.2.0

--- a/src/envs/wxvx.yaml
+++ b/src/envs/wxvx.yaml
@@ -10,4 +10,4 @@ dependencies:
   - wxvx >=0.7.2
   - xesmf 0.8.*
   - pip:
-      - eagle-tools
+      - eagle-tools==0.8.1

--- a/src/envs/wxvx.yaml
+++ b/src/envs/wxvx.yaml
@@ -9,5 +9,6 @@ dependencies:
   - uwtools 2.14.*
   - wxvx >=0.7.2
   - xesmf 0.8.*
+  - zarr 2.18.*
   - pip:
       - eagle-tools==0.8.1

--- a/src/envs/wxvx.yaml
+++ b/src/envs/wxvx.yaml
@@ -4,6 +4,7 @@ channels:
   - oar-gsl
   - ufs-community
 dependencies:
+  - pip
   - python 3.13
   - uwtools 2.14.*
   - wxvx >=0.7.2


### PR DESCRIPTION
## Description:

The `wxvx` conda environment was recently updated to include both `wxvx` and `eagle-tools` -- the latter used to preprocess forecast netCDF for verification -- but `wxvx` was pinned to a version of the `zarr` package greater than highest version `eagle-tools` specifies that it supports. This led to `pip`, when installing `eagle-tools`, downgrading the `zarr` version installed by conda for `wxvx`, and leading to the inaccurate but alarming message reported in #155.

This PR:

- Updates several `envs/*.yaml` files to install `pip` in each conda environment, rather than in `base`, as advised in the [conda documentation](https://www.anaconda.com/docs/getting-started/working-with-conda/packages/pip-install#writing-an-environment-yml-file).
- Pins `eagle-tools` to version `0.8.1` in `wxvx.yaml`.
- Pins `zarr` to version `2.18.*` (acceptable both to the just-released `wxvx` version `0.7.2-1`, which accepts a range of `zarr` versions; and to `eagle-tools`) in `wxvx.yaml`.

Fixes #155.

## Type of change:

- [x] Bug fix

## Area(s) affected

- [x] Other: software runtime

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Testing / Verification:

CI pipeline and code-quality tests will pass before merge.
