### PR TITLE
Feature: Add additional resolution options for target grids and latent mesh

### DIFF
--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -355,9 +355,9 @@ training:
     system:
       input:
         global_dataset: '{{ val.data.rundir }}/gfs.zarr'
-        graph: '{{ val.data.rundir }}/graph.latentx2.spongex1.12knn.pt'
+        graph: '{{ val.data.rundir }}/{{ val.filenames.graph }}'
         lam_dataset: '{{ val.data.rundir }}/hrrr.zarr'
-        latent_mesh: '{{ val.data.rundir }}/latentx2.spongex1.combined.sorted.npz'
+        latent_mesh: '{{ val.data.rundir }}/{{ val.filenames.latent_mesh }}'
       hardware:
         num_gpus_per_model: 1
       output:
@@ -514,6 +514,7 @@ val:
     gfs_target_grid: global_one_degree.nc
     hrrr_target_grid: hrrr_15km.nc
     latent_mesh: latentx2.spongex1.combined.sorted.npz
+    graph: graph.latentx2.spongex1.12knn.pt
   levels: [100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
   statsdelta:
     aligned: !timedelta '{{ (val.statsdelta.raw - val.statsdelta.raw % app.time.step).total_seconds() / 3600 }}'
@@ -866,7 +867,7 @@ zarrs:
         target: !dict '{{ ufs2arco.target }}'
         transforms:
           horizontal_regrid:
-            regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_719x1440_180x360.nc") }}'
+            regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_weights_gfs.nc") }}'
             target_grid_path: '{{ val.data.rundir}}/{{ val.filenames.gfs_target_grid }}'
     platform: !dict '{{ app.platform }}'
   hrrr:
@@ -894,6 +895,6 @@ zarrs:
         target: !dict '{{ ufs2arco.target }}'
         transforms:
           horizontal_regrid:
-            regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_1059x1799_211x359.nc") }}'
+            regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_weights_hrrr.nc"") }}'
             target_grid_path: '{{ val.data.rundir }}/{{ val.filenames.hrrr_target_grid }}'
     platform: !dict '{{ app.platform }}'

--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -895,6 +895,6 @@ zarrs:
         target: !dict '{{ ufs2arco.target }}'
         transforms:
           horizontal_regrid:
-            regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_weights_hrrr.nc"") }}'
+            regridder_kwargs: !dict '{{ dict(ufs2arco.regridder, filename="conservative_weights_hrrr.nc") }}'
             target_grid_path: '{{ val.data.rundir }}/{{ val.filenames.hrrr_target_grid }}'
     platform: !dict '{{ app.platform }}'

--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -24,6 +24,10 @@ grids_and_meshes:
     hrrr_target_grid: '{{ val.filenames.hrrr_target_grid }}'
     latent_mesh: '{{ val.filenames.latent_mesh }}'
   rundir: '{{ val.data.rundir }}'
+  conus_grid_resolution_km: 15
+  global_grid_resolution_deg: 1.0
+  latent_mesh_global_resolution_deg: 2.0
+  latent_mesh_conus_coarsen_factor: 2
 inference:
   anemoi:
     checkpoint_path: /path/to/checkpoint # NB: If a value for inference.checkpoint_dir is provided, it will override this value with the latest checkpoint in that directory.

--- a/src/eagle/data/grids_and_meshes.jsonschema
+++ b/src/eagle/data/grids_and_meshes.jsonschema
@@ -16,20 +16,55 @@
               "type": "string"
             }
           },
-          "required": [
-            "gfs_target_grid",
-            "hrrr_target_grid",
-            "latent_mesh"
-          ],
           "type": "object"
         },
         "rundir": {
           "type": "string"
+        },
+        "conus_grid_resolution_km": {
+          "description": "The resolution of the CONUS grid in km. Must be a multiple of 3km (HRRR native resolution).",
+          "type": "integer",
+          "minimum": 3,
+          "multipleOf": 3
+        },
+        "global_grid_resolution_deg": {
+          "description": "The global GFS target grid resolution in degrees. Supported values are native 0.25 or regridded 1.0.",
+          "type": "number",
+          "enum": [0.25, 1.0]
+        },
+        "latent_mesh_global_resolution_deg": {
+          "description": "The global resolution in degrees used to build the global latent mesh component.",
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "latent_mesh_conus_coarsen_factor": {
+          "description": "Coarsening factor used to subsample CONUS bounds for latent mesh generation.",
+          "type": "integer",
+          "minimum": 1
         }
       },
       "required": [
+        "conus_grid_resolution_km",
         "filenames",
+        "global_grid_resolution_deg",
         "rundir"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "filenames": {
+                "required": ["latent_mesh"]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "latent_mesh_global_resolution_deg",
+              "latent_mesh_conus_coarsen_factor"
+            ]
+          }
+        }
       ],
       "type": "object"
     }

--- a/src/eagle/data/grids_and_meshes.jsonschema
+++ b/src/eagle/data/grids_and_meshes.jsonschema
@@ -2,7 +2,32 @@
   "properties": {
     "grids_and_meshes": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "filenames": {
+                "required": [
+                  "latent_mesh"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "latent_mesh_global_resolution_deg",
+              "latent_mesh_conus_coarsen_factor"
+            ]
+          }
+        }
+      ],
       "properties": {
+        "conus_grid_resolution_km": {
+          "description": "The resolution of the CONUS grid in km. Must be a multiple of 3km (HRRR native resolution).",
+          "minimum": 3,
+          "multipleOf": 3,
+          "type": "integer"
+        },
         "filenames": {
           "additionalProperties": false,
           "properties": {
@@ -18,29 +43,26 @@
           },
           "type": "object"
         },
-        "rundir": {
-          "type": "string"
-        },
-        "conus_grid_resolution_km": {
-          "description": "The resolution of the CONUS grid in km. Must be a multiple of 3km (HRRR native resolution).",
-          "type": "integer",
-          "minimum": 3,
-          "multipleOf": 3
-        },
         "global_grid_resolution_deg": {
           "description": "The global GFS target grid resolution in degrees. Supported values are native 0.25 or regridded 1.0.",
-          "type": "number",
-          "enum": [0.25, 1.0]
-        },
-        "latent_mesh_global_resolution_deg": {
-          "description": "The global resolution in degrees used to build the global latent mesh component.",
-          "type": "number",
-          "exclusiveMinimum": 0
+          "enum": [
+            0.25,
+            1.0
+          ],
+          "type": "number"
         },
         "latent_mesh_conus_coarsen_factor": {
           "description": "Coarsening factor used to subsample CONUS bounds for latent mesh generation.",
-          "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "type": "integer"
+        },
+        "latent_mesh_global_resolution_deg": {
+          "description": "The global resolution in degrees used to build the global latent mesh component.",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "rundir": {
+          "type": "string"
         }
       },
       "required": [
@@ -48,23 +70,6 @@
         "filenames",
         "global_grid_resolution_deg",
         "rundir"
-      ],
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "filenames": {
-                "required": ["latent_mesh"]
-              }
-            }
-          },
-          "then": {
-            "required": [
-              "latent_mesh_global_resolution_deg",
-              "latent_mesh_conus_coarsen_factor"
-            ]
-          }
-        }
       ],
       "type": "object"
     }

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -121,8 +121,7 @@ class GridsAndMeshes(AssetsTimeInvariant):
             return (
                 self.rundir / self.config["filenames"]["hrrr_target_grid"]
             ).with_suffix(".log")
-        else:
-            return self.rundir / "hrrr_target_grid.log"
+        return self.rundir / "hrrr_target_grid.log"
 
 
 # Private functions

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -33,10 +33,8 @@ class GridsAndMeshes(AssetsTimeInvariant):
         """
         The CONUS grid, provisioned to the rundir.
         """
-        if "hrrr_target_grid" not in self.config.get("filenames", {}):
-            return
         res = self.config["conus_grid_resolution_km"]
-        if res == 3:
+        if res == 3 or "hrrr_target_grid" not in self.config["filenames"]:
             return
         path = self.rundir / self.config["filenames"]["hrrr_target_grid"]
         yield self.taskname(f"conus data grid {path}")
@@ -52,17 +50,15 @@ class GridsAndMeshes(AssetsTimeInvariant):
         """
         The global grid, provisioned to the rundir.
         """
-        if "gfs_target_grid" not in self.config.get("filenames", {}):
-            return
-        resolution = self.config["global_grid_resolution_deg"]
-        if resolution == 0.25:
+        res = self.config["global_grid_resolution_deg"]
+        if res == 0.25 or "gfs_target_grid" not in self.config["filenames"]:
             return
         path = self.rundir / self.config["filenames"]["gfs_target_grid"]
         yield self.taskname(f"global data grid {path}")
         yield Asset(path, path.is_file)
         yield None
         path.parent.mkdir(parents=True, exist_ok=True)
-        ds = xesmf.util.grid_global(resolution, resolution, cf=True, lon1=360)
+        ds = xesmf.util.grid_global(res, res, cf=True, lon1=360)
         ds = ds.drop_vars("latitude_longitude")
         ds = ds.sortby("lat", ascending=False)  # GFS goes north -> south
         ds.to_netcdf(path)
@@ -72,7 +68,7 @@ class GridsAndMeshes(AssetsTimeInvariant):
         """
         The latent mesh, provisioned to the rundir.
         """
-        if "latent_mesh" not in self.config.get("filenames", {}):
+        if "latent_mesh" not in self.config["filenames"]:
             return
         path = self.rundir / self.config["filenames"]["latent_mesh"]
         yield self.taskname(f"latent mesh {path}")
@@ -96,13 +92,13 @@ class GridsAndMeshes(AssetsTimeInvariant):
         yield self.taskname("provisioned run directory")
         tasks = []
 
-        if "hrrr_target_grid" in self.config.get("filenames", {}):
+        if "hrrr_target_grid" in self.config["filenames"]:
             tasks.append(self.conus_data_grid())
 
-        if "gfs_target_grid" in self.config.get("filenames", {}):
+        if "gfs_target_grid" in self.config["filenames"]:
             tasks.append(self.global_data_grid())
 
-        if "latent_mesh" in self.config.get("filenames", {}):
+        if "latent_mesh" in self.config["filenames"]:
             tasks.append(self.latent_mesh())
 
         yield tasks

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -16,6 +16,7 @@ from iotaa import Asset, collection, task  # provided by uwtools
 from ufs2arco import sources  # type: ignore[import-untyped]
 from uwtools.api.driver import AssetsTimeInvariant
 from xarray import Dataset
+import xarray as xr
 
 LOCK = Lock()
 
@@ -32,24 +33,36 @@ class GridsAndMeshes(AssetsTimeInvariant):
         """
         The CONUS grid, provisioned to the rundir.
         """
+        if "hrrr_target_grid" not in self.config.get("filenames", {}):
+            return
+        res = self.config["conus_grid_resolution_km"]
+        if res == 3:
+            return
         path = self.rundir / self.config["filenames"]["hrrr_target_grid"]
         yield self.taskname(f"conus data grid {path}")
         yield Asset(path, path.is_file)
         yield None
         path.parent.mkdir(parents=True, exist_ok=True)
-        _conus_data_grid(self.rundir, self._conus_data_grid_logfile).to_netcdf(path)
+        _conus_data_grid(self.rundir, self._conus_data_grid_logfile, res).to_netcdf(
+            path
+        )
 
     @task
     def global_data_grid(self):
         """
         The global grid, provisioned to the rundir.
         """
+        if "gfs_target_grid" not in self.config.get("filenames", {}):
+            return
+        resolution = self.config["global_grid_resolution_deg"]
+        if resolution == 0.25:
+            return
         path = self.rundir / self.config["filenames"]["gfs_target_grid"]
         yield self.taskname(f"global data grid {path}")
         yield Asset(path, path.is_file)
         yield None
         path.parent.mkdir(parents=True, exist_ok=True)
-        ds = xesmf.util.grid_global(1, 1, cf=True, lon1=360)
+        ds = xesmf.util.grid_global(resolution, resolution, cf=True, lon1=360)
         ds = ds.drop_vars("latitude_longitude")
         ds = ds.sortby("lat", ascending=False)  # GFS goes north -> south
         ds.to_netcdf(path)
@@ -59,14 +72,18 @@ class GridsAndMeshes(AssetsTimeInvariant):
         """
         The latent mesh, provisioned to the rundir.
         """
+        if "latent_mesh" not in self.config.get("filenames", {}):
+            return
         path = self.rundir / self.config["filenames"]["latent_mesh"]
         yield self.taskname(f"latent mesh {path}")
         yield Asset(path, path.is_file)
         yield None
         path.parent.mkdir(parents=True, exist_ok=True)
-        gmesh = _global_latent_grid()
+        res = self.config["conus_grid_resolution_km"]
+        gmesh = _global_latent_grid(self.config["latent_mesh_global_resolution_deg"])
         cmesh = _conus_latent_grid(
-            _conus_data_grid(self.rundir, self._conus_data_grid_logfile)
+            _conus_data_grid(self.rundir, self._conus_data_grid_logfile, res),
+            coarsen=self.config["latent_mesh_conus_coarsen_factor"],
         )
         coords = _combine_global_and_conus_meshes(gmesh, cmesh)
         np.savez(path, lon=coords["lon"], lat=coords["lat"])
@@ -77,11 +94,18 @@ class GridsAndMeshes(AssetsTimeInvariant):
         Run directory provisioned with all required content.
         """
         yield self.taskname("provisioned run directory")
-        yield [
-            self.conus_data_grid(),
-            self.global_data_grid(),
-            self.latent_mesh(),
-        ]
+        tasks = []
+
+        if "hrrr_target_grid" in self.config.get("filenames", {}):
+            tasks.append(self.conus_data_grid())
+
+        if "gfs_target_grid" in self.config.get("filenames", {}):
+            tasks.append(self.global_data_grid())
+
+        if "latent_mesh" in self.config.get("filenames", {}):
+            tasks.append(self.latent_mesh())
+
+        yield tasks
 
     # Public methods
 
@@ -93,9 +117,12 @@ class GridsAndMeshes(AssetsTimeInvariant):
 
     @property
     def _conus_data_grid_logfile(self):
-        return (self.rundir / self.config["filenames"]["hrrr_target_grid"]).with_suffix(
-            ".log"
-        )
+        if "hrrr_target_grid" in self.config.get("filenames", {}):
+            return (
+                self.rundir / self.config["filenames"]["hrrr_target_grid"]
+            ).with_suffix(".log")
+        else:
+            return self.rundir / "hrrr_target_grid.log"
 
 
 # Private functions
@@ -124,7 +151,7 @@ def _combine_global_and_conus_meshes(
 
 
 @cache
-def _conus_data_grid(rundir: Path, logfile: Path) -> Dataset:
+def _conus_data_grid(rundir: Path, logfile: Path, resolution_km: int = 15) -> Dataset:
     with LOCK:
         with _logging_to_file(logfile):
             hrrr = sources.AWSHRRRArchive(
@@ -149,20 +176,37 @@ def _conus_data_grid(rundir: Path, logfile: Path) -> Dataset:
             hds = hds.assign_coords({f"{key}_b": corners})
             hds = hds.drop_vars(f"{key}_bounds")
         hds = hds.rename({"x_vertices": "x_b", "y_vertices": "y_b"})
+
+        stride = resolution_km // 3
         # Get the nodes and bounds by subsampling.
-        hds = hds.isel(
-            x=slice(None, -4, None),
-            y=slice(None, -4, None),
-            x_b=slice(None, -4, None),
-            y_b=slice(None, -4, None),
-        )
-        cds: Dataset = hds.isel(
-            x=slice(2, None, 5),
-            y=slice(2, None, 5),
-            x_b=slice(0, None, 5),
-            y_b=slice(0, None, 5),
-        )
-        return cds.drop_vars("orog")
+        trim = stride - 1
+        if trim > 0:
+            hds = hds.isel(
+                x=slice(None, -trim),
+                y=slice(None, -trim),
+                x_b=slice(None, -trim),
+                y_b=slice(None, -trim),
+            )
+        if stride % 2 == 1:
+            # Odd stride: centers align with original centers (e.g. 15km, stride=5)
+            cds = hds.isel(
+                x=slice(stride // 2, None, stride),
+                y=slice(stride // 2, None, stride),
+                x_b=slice(0, None, stride),
+                y_b=slice(0, None, stride),
+            ).drop_vars("orog")
+        else:
+            # Even stride: centers align with original vertices (e.g. 6km, stride=2)
+            centers = hds.isel(
+                x_b=slice(stride // 2, None, stride),
+                y_b=slice(stride // 2, None, stride),
+            )
+            centers = centers.drop_vars(["lat", "lon", "orog"]).rename(
+                {"lat_b": "lat", "lon_b": "lon", "x_b": "x", "y_b": "y"}
+            )
+            bounds = hds.isel(x_b=slice(0, None, stride), y_b=slice(0, None, stride))
+            cds = xr.merge([centers, bounds.drop_vars(["lat", "lon", "orog"])])
+        return cds
 
 
 def _conus_latent_grid(cds: Dataset, trim: int = 10, coarsen: int = 2) -> Dataset:
@@ -180,13 +224,13 @@ def _conus_latent_grid(cds: Dataset, trim: int = 10, coarsen: int = 2) -> Datase
     )
 
 
-def _global_latent_grid() -> Dataset:
+def _global_latent_grid(resolution_deg: float) -> Dataset:
     """
     For the high-res version, this will process the original grid. However, since the
     data grid is on an xESMF generated grid, it works out just fine to generate another
     xESMF grid here.
     """
-    mesh: Dataset = xesmf.util.grid_global(2, 2, cf=True, lon1=360)
+    mesh: Dataset = xesmf.util.grid_global(resolution_deg, resolution_deg, cf=True, lon1=360)
     return mesh.drop_vars("latitude_longitude")
 
 

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -113,7 +113,7 @@ class GridsAndMeshes(AssetsTimeInvariant):
 
     @property
     def _conus_data_grid_logfile(self):
-        if "hrrr_target_grid" in self.config.get("filenames", {}):
+        if "hrrr_target_grid" in self.config["filenames"]:
             return (
                 self.rundir / self.config["filenames"]["hrrr_target_grid"]
             ).with_suffix(".log")

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -182,9 +182,10 @@ def _conus_data_grid(rundir: Path, logfile: Path, resolution_km: int = 15) -> Da
                 x_b=slice(None, -trim),
                 y_b=slice(None, -trim),
             )
+        cds: Dataset
         if stride % 2 == 1:
             # Odd stride: centers align with original centers (e.g. 15km, stride=5)
-            cds: Dataset = hds.isel(
+            cds = hds.isel(
                 x=slice(stride // 2, None, stride),
                 y=slice(stride // 2, None, stride),
                 x_b=slice(0, None, stride),
@@ -200,7 +201,7 @@ def _conus_data_grid(rundir: Path, logfile: Path, resolution_km: int = 15) -> Da
                 {"lat_b": "lat", "lon_b": "lon", "x_b": "x", "y_b": "y"}
             )
             bounds = hds.isel(x_b=slice(0, None, stride), y_b=slice(0, None, stride))
-            cds: Dataset = xr.merge([centers, bounds.drop_vars(["lat", "lon", "orog"])])
+            cds = xr.merge([centers, bounds.drop_vars(["lat", "lon", "orog"])])
         return cds
 
 

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -7,6 +7,7 @@ from threading import Lock
 
 import cf_xarray as cfxr
 import numpy as np
+import xarray as xr
 import xesmf  # type: ignore[import-untyped]
 from anemoi.graphs.generate.utils import (  # type: ignore[import-untyped]
     get_coordinates_ordering,
@@ -16,7 +17,6 @@ from iotaa import Asset, collection, task  # provided by uwtools
 from ufs2arco import sources  # type: ignore[import-untyped]
 from uwtools.api.driver import AssetsTimeInvariant
 from xarray import Dataset
-import xarray as xr
 
 LOCK = Lock()
 
@@ -229,7 +229,9 @@ def _global_latent_grid(resolution_deg: float) -> Dataset:
     data grid is on an xESMF generated grid, it works out just fine to generate another
     xESMF grid here.
     """
-    mesh: Dataset = xesmf.util.grid_global(resolution_deg, resolution_deg, cf=True, lon1=360)
+    mesh: Dataset = xesmf.util.grid_global(
+        resolution_deg, resolution_deg, cf=True, lon1=360
+    )
     return mesh.drop_vars("latitude_longitude")
 
 

--- a/src/eagle/data/grids_and_meshes.py
+++ b/src/eagle/data/grids_and_meshes.py
@@ -184,7 +184,7 @@ def _conus_data_grid(rundir: Path, logfile: Path, resolution_km: int = 15) -> Da
             )
         if stride % 2 == 1:
             # Odd stride: centers align with original centers (e.g. 15km, stride=5)
-            cds = hds.isel(
+            cds: Dataset = hds.isel(
                 x=slice(stride // 2, None, stride),
                 y=slice(stride // 2, None, stride),
                 x_b=slice(0, None, stride),
@@ -200,7 +200,7 @@ def _conus_data_grid(rundir: Path, logfile: Path, resolution_km: int = 15) -> Da
                 {"lat_b": "lat", "lon_b": "lon", "x_b": "x", "y_b": "y"}
             )
             bounds = hds.isel(x_b=slice(0, None, stride), y_b=slice(0, None, stride))
-            cds = xr.merge([centers, bounds.drop_vars(["lat", "lon", "orog"])])
+            cds: Dataset = xr.merge([centers, bounds.drop_vars(["lat", "lon", "orog"])])
         return cds
 
 

--- a/src/eagle/data/grids_and_meshes_test.py
+++ b/src/eagle/data/grids_and_meshes_test.py
@@ -61,9 +61,7 @@ def test_grids_and_meshes(logged, tmp_path, validator, with_del, with_set):
         assert logged("is not of type 'string'")
 
 
-def test_grids_and_meshes__conus_grid_resolution_km(
-    logged, tmp_path, validator
-):
+def test_grids_and_meshes__conus_grid_resolution_km(logged, tmp_path, validator):
     ok = validator(
         __file__,
         "grids_and_meshes",
@@ -85,9 +83,7 @@ def test_grids_and_meshes__conus_grid_resolution_km(
     assert logged("is not of type 'integer'")
 
 
-def test_grids_and_meshes__global_grid_resolution_deg(
-    logged, tmp_path, validator
-):
+def test_grids_and_meshes__global_grid_resolution_deg(logged, tmp_path, validator):
     ok = validator(
         __file__,
         "grids_and_meshes",

--- a/src/eagle/data/grids_and_meshes_test.py
+++ b/src/eagle/data/grids_and_meshes_test.py
@@ -62,7 +62,7 @@ def test_grids_and_meshes(logged, tmp_path, validator, with_del, with_set):
 
 
 def test_grids_and_meshes__conus_grid_resolution_km(
-    logged, tmp_path, validator, with_set
+    logged, tmp_path, validator
 ):
     ok = validator(
         __file__,

--- a/src/eagle/data/grids_and_meshes_test.py
+++ b/src/eagle/data/grids_and_meshes_test.py
@@ -98,7 +98,7 @@ def test_grids_and_meshes__global_grid_resolution_deg(logged, tmp_path, validato
     assert ok(1.0)
     # Invalid values:
     assert not ok(2.0)
-    assert logged("is not one of [0.25, 1.0]")
+    assert logged(r"is not one of \[0.25, 1.0\]")
     assert not ok("1.0")
     assert logged("is not of type 'number'")
 

--- a/src/eagle/data/grids_and_meshes_test.py
+++ b/src/eagle/data/grids_and_meshes_test.py
@@ -7,6 +7,10 @@ CONFIG = {
             "hrrr_target_grid": "/path/to/hrrr_15km.nc",
             "latent_mesh": "/path/to/latentx2.spongex1.combined.sorted.npz",
         },
+        "conus_grid_resolution_km": 15,
+        "global_grid_resolution_deg": 1.0,
+        "latent_mesh_global_resolution_deg": 2.0,
+        "latent_mesh_conus_coarsen_factor": 2,
         "rundir": "/path/to/rundir",
     },
 }
@@ -39,7 +43,12 @@ def test_grids_and_meshes(logged, tmp_path, validator, with_del, with_set):
     # Additional keys are not allowed:
     assert not ok(with_set(config, "foo", "bar"))
     # Certain keys are required:
-    for key in ["filenames", "rundir"]:
+    for key in [
+        "conus_grid_resolution_km",
+        "filenames",
+        "global_grid_resolution_deg",
+        "rundir",
+    ]:
         assert not ok(with_del(config, key))
         assert logged(f"'{key}' is a required property")
     # Some keys have object values:
@@ -50,6 +59,97 @@ def test_grids_and_meshes(logged, tmp_path, validator, with_del, with_set):
     for key in ["rundir"]:
         assert not ok(with_set(config, None, key))
         assert logged("is not of type 'string'")
+
+
+def test_grids_and_meshes__conus_grid_resolution_km(
+    logged, tmp_path, validator, with_set
+):
+    ok = validator(
+        __file__,
+        "grids_and_meshes",
+        tmp_path,
+        "properties",
+        "grids_and_meshes",
+        "properties",
+        "conus_grid_resolution_km",
+    )
+    # Basic correctness:
+    assert ok(6)
+    assert ok(15)
+    # Invalid values:
+    assert not ok(4)
+    assert logged("is not a multiple of 3")
+    assert not ok(1)
+    assert logged("is less than the minimum of 3")
+    assert not ok("6")
+    assert logged("is not of type 'integer'")
+
+
+def test_grids_and_meshes__global_grid_resolution_deg(
+    logged, tmp_path, validator
+):
+    ok = validator(
+        __file__,
+        "grids_and_meshes",
+        tmp_path,
+        "properties",
+        "grids_and_meshes",
+        "properties",
+        "global_grid_resolution_deg",
+    )
+    # Basic correctness:
+    assert ok(0.25)
+    assert ok(1.0)
+    # Invalid values:
+    assert not ok(2.0)
+    assert logged("is not one of [0.25, 1.0]")
+    assert not ok("1.0")
+    assert logged("is not of type 'number'")
+
+
+def test_grids_and_meshes__latent_mesh_global_resolution_deg(
+    logged, tmp_path, validator
+):
+    ok = validator(
+        __file__,
+        "grids_and_meshes",
+        tmp_path,
+        "properties",
+        "grids_and_meshes",
+        "properties",
+        "latent_mesh_global_resolution_deg",
+    )
+    # Basic correctness:
+    assert ok(2.0)
+    # Invalid values:
+    assert not ok(0.0)
+    assert logged("is less than or equal to the minimum of 0")
+    assert not ok(-1.0)
+    assert logged("is less than or equal to the minimum of 0")
+    assert not ok("2.0")
+    assert logged("is not of type 'number'")
+
+
+def test_grids_and_meshes__latent_mesh_conus_coarsen_factor(
+    logged, tmp_path, validator
+):
+    ok = validator(
+        __file__,
+        "grids_and_meshes",
+        tmp_path,
+        "properties",
+        "grids_and_meshes",
+        "properties",
+        "latent_mesh_conus_coarsen_factor",
+    )
+    # Basic correctness:
+    assert ok(1)
+    assert ok(2)
+    # Invalid values:
+    assert not ok(0)
+    assert logged("is less than the minimum of 1")
+    assert not ok(1.5)
+    assert logged("is not of type 'integer'")
 
 
 def test_grids_and_meshes__filenames(logged, tmp_path, validator, with_del, with_set):
@@ -67,11 +167,31 @@ def test_grids_and_meshes__filenames(logged, tmp_path, validator, with_del, with
     assert ok(config)
     # Additional keys are not allowed:
     assert not ok(with_set(config, "foo", "bar"))
-    # Certain keys are required:
+    # Optional keys:
     for key in ["gfs_target_grid", "hrrr_target_grid", "latent_mesh"]:
-        assert not ok(with_del(config, key))
-        assert logged(f"'{key}' is a required property")
+        assert ok(with_del(config, key))
     # Some keys have string values:
     for key in ["gfs_target_grid", "hrrr_target_grid", "latent_mesh"]:
         assert not ok(with_set(config, None, key))
         assert logged("is not of type 'string'")
+
+
+def test_grids_and_meshes__latent_mesh_settings_conditional_required(
+    logged, tmp_path, validator, with_del, with_set
+):
+    ok = validator(
+        __file__, "grids_and_meshes", tmp_path, "properties", "grids_and_meshes"
+    )
+    config = CONFIG["grids_and_meshes"]
+    # If latent mesh is requested, latent mesh settings are required.
+    assert not ok(with_del(config, "latent_mesh_global_resolution_deg"))
+    assert logged("'latent_mesh_global_resolution_deg' is a required property")
+    assert not ok(with_del(config, "latent_mesh_conus_coarsen_factor"))
+    assert logged("'latent_mesh_conus_coarsen_factor' is a required property")
+    # If latent mesh is not requested, latent mesh settings may be omitted.
+    filenames_without_latent_mesh = with_del(config["filenames"], "latent_mesh")
+    config_without_latent_mesh = with_set(
+        config, filenames_without_latent_mesh, "filenames"
+    )
+    assert ok(with_del(config_without_latent_mesh, "latent_mesh_global_resolution_deg"))
+    assert ok(with_del(config_without_latent_mesh, "latent_mesh_conus_coarsen_factor"))


### PR DESCRIPTION
nested-eagle was trained using a 6km hrrr grid and 0.25 degree gfs grid. This PR introduces functionality for users to easily change the resolution of target grids or the latent mesh. It also makes it possible for a user to completely skip creating these grids if they do not need any regridding or maybe do not intend on using a latent mesh. 

The OG 15km/1deg set up works out of the box still.

Lets say you want to do the nested-eagle 6km/0.25deg setup:
1) remove `grids_and_meshes.filenames.gfs_target_grid` (removing from this list means the step is skipped now)
2) change `grids_and_meshes.global_grid_resolution_deg` to 0.25 (1 and 0.25 are now supported)
3) change `grids_and_meshes.conus_grid_resolution_km` to 6
4) remove `gfs.zarr.ufs2arco.transforms` (we are no longer regridding and using native 0.25 degree)
5) change `val.filenames.hrrr_target_grid` to hrrr_6km.nc. Can remove gfs from this list too, but this is not technically necessary because downstream things that have called it have been removed. Users may wish to remove for readability/clarity.
6) update memory per cpu on data jobs now that we have increased resolution (I did 10)





## Type of change:
<!--
Indicate PR type of change.
Delete options that are not applicable. 
-->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Other:

## Area(s) affected
<!-- Check all that apply -->
- [x] nested_eagle workflow
- [ ] Verification / evaluation (via WXVX)
- [x] Data prep / UFS2ARCO
- [ ] Config (YAML)
- [ ] Plotting / post-processing
- [ ] Infrastructure / Slurm scripts
- [ ] Other:

## Commit Requirements:
<!--
- Check off completed items. Use [X] for a filled in checkbox or leave it [ ] for an empty checkbox
- Your pull request (PR) will not be considered until all requirements are met.
- THIS IS YOUR RESPONSIBILITY
-->
- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary