### PR TITLE
Run training and inference under srun on Ursa

### DIFF
--- a/.github/scripts/fsclean
+++ b/.github/scripts/fsclean
@@ -60,6 +60,7 @@ else
   echo RECLAIMED $reclaimed GB
   if [[ $final -lt $GIGSREQD ]]; then
     msg $final STOPPING
+    echo "A manual re-run of this CI job may succeed if the next runner has more free space."
     exit 1
   fi
   msg $final OK

--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -55,7 +55,7 @@ inference:
     envcmds:
       - source {{ val.conda }}/etc/profile.d/conda.sh
       - conda activate anemoi
-      - set -ex
+      - set -e
     executable: '{{ app.launcher | default("") }} eagle-tools inference inference.yaml'
   rundir: '{{ app.rundir }}/inference'
 platform: !dict '{{ app.platform }}'
@@ -442,9 +442,9 @@ training:
     envcmds:
       - source {{ val.conda }}/etc/profile.d/conda.sh
       - conda activate anemoi
-      - set -ex
       - export SLURM_GPUS_PER_NODE=1
       - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+      - set -e
     executable: '{{ app.launcher | default("") }} anemoi-training train --config-name=training'
   remove:
     # Dot-separated config keys paths to delete from the composed runtime config.
@@ -835,10 +835,6 @@ vx:
           regrid: !dict '{{ vx.grid2obs.global.wxvx.wxvx.regrid }}'
 zarrs:
   common:
-    envcmds:
-      - source {{ val.conda }}/etc/profile.d/conda.sh
-      - conda activate data
-      - set -ex
     execution:
       batchargs:
         cores: 4
@@ -846,7 +842,10 @@ zarrs:
         partition: '{{ app.partitions.netaccess }}'
         rundir: '{{ val.data.rundir }}'
         walltime: '00:10:00'
-      envcmds: !list '{{ zarrs.common.envcmds }}'
+      envcmds:
+        - source {{ val.conda }}/etc/profile.d/conda.sh
+        - conda activate data
+        - set -e
       mpiargs: []
       mpicmd: '{{ "srun" if app.platform.scheduler == "slurm" else "mpiexec" }}'
   gfs:

--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -55,7 +55,7 @@ inference:
       - source {{ val.conda }}/etc/profile.d/conda.sh
       - conda activate anemoi
       - set -ex
-    executable: eagle-tools inference inference.yaml
+    executable: '{{ app.launcher | default("") }} eagle-tools inference inference.yaml'
   rundir: '{{ app.rundir }}/inference'
 platform: !dict '{{ app.platform }}'
 prewxvx:
@@ -444,7 +444,7 @@ training:
       - set -ex
       - export SLURM_GPUS_PER_NODE=1
       - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
-    executable: anemoi-training train --config-name=training
+    executable: '{{ app.launcher | default("") }} anemoi-training train --config-name=training'
   remove:
     # Dot-separated config keys paths to delete from the composed runtime config.
     - graph.nodes.hidden.node_builder.grid

--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -31,18 +31,19 @@ grids_and_meshes:
 inference:
   anemoi:
     checkpoint_path: /path/to/checkpoint # NB: If a value for inference.checkpoint_dir is provided, it will override this value with the latest checkpoint in that directory.
+    end_date: !datetime '{{ app.time.inference_stop }}'
+    freq: '{{ app.time.freq }}'
     input_dataset_kwargs: &dataset-kwargs
+      adjust: all
       cutout:
         - dataset: '{{ grids_and_meshes.rundir }}/hrrr.zarr'
           trim_edge: [10, 11, 10, 11]
         - dataset: '{{ grids_and_meshes.rundir }}/gfs.zarr'
-      adjust: all
       min_distance_km: 0
-    end_date: !datetime '{{ app.time.inference_stop }}'
-    freq: '{{ app.time.freq }}'
     lead_time: !int '{{ app.time.leadtime }}'
     output_path: '{{ inference.rundir }}/output'
     start_date: !datetime '{{ app.time.inference_start }}'
+    use_mpi: true
   checkpoint_dir: '{{ training.rundir }}/outputs/checkpoint'
   execution:
     batchargs:

--- a/src/config/ursa.yaml
+++ b/src/config/ursa.yaml
@@ -9,11 +9,28 @@ app:
       nodes: 1
       partition: u1-h100
       queue: gpuwf
+  launcher: srun --export=ALL
   partitions:
     netaccess: u1-service
   platform: &platform
     account: epic
     scheduler: slurm
+inference:
+  execution:
+    envcmds: # PM DRY THIS OUT
+      - source /etc/profile.d/profile-slurm.sh
+      - source {{ val.conda }}/etc/profile.d/conda.sh
+      - conda activate anemoi
+      - set -ex
+training:
+  execution:
+    envcmds: # PM DRY THIS OUT
+      - source /etc/profile.d/profile-slurm.sh
+      - source {{ val.conda }}/etc/profile.d/conda.sh
+      - conda activate anemoi
+      - set -ex
+      - export SLURM_GPUS_PER_NODE=1
+      - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 zarrs:
   common:
     execution:

--- a/src/config/ursa.yaml
+++ b/src/config/ursa.yaml
@@ -17,25 +17,18 @@ app:
     scheduler: slurm
 inference:
   execution:
-    envcmds: # PM DRY THIS OUT
+    envcmds: !extend
       - source /etc/profile.d/profile-slurm.sh
-      - source {{ val.conda }}/etc/profile.d/conda.sh
-      - conda activate anemoi
-      - set -ex
 training:
   execution:
-    envcmds: # PM DRY THIS OUT
+    envcmds: !extend
       - source /etc/profile.d/profile-slurm.sh
-      - source {{ val.conda }}/etc/profile.d/conda.sh
-      - conda activate anemoi
-      - set -ex
-      - export SLURM_GPUS_PER_NODE=1
-      - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 zarrs:
   common:
     execution:
       batchargs:
         --mem-per-cpu: 3G
-      envcmds: !list '{{ ["source /etc/profile.d/profile-slurm.sh"] + zarrs.common.envcmds }}'
+      envcmds: !extend
+        - source /etc/profile.d/profile-slurm.sh
       mpiargs:
         - "--export=ALL"

--- a/src/envs/anemoi.yaml
+++ b/src/envs/anemoi.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pip
   - python 3.12
   - setuptools 81.0.*
-  - uwtools 2.14.*
+  - uwtools 2.16.*
   - pip:
       - anemoi-inference==0.10.*
       - anemoi-models==0.13.*

--- a/src/envs/anemoi.yaml
+++ b/src/envs/anemoi.yaml
@@ -4,6 +4,7 @@ channels:
   - ufs-community
 dependencies:
   - flash-attn 2.8.*
+  - mpi4py 4.1.*
   - numpy 2.2.6.*
   - pip
   - python 3.12

--- a/src/envs/base.yaml
+++ b/src/envs/base.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - ufs-community
 dependencies:
-  - uwtools 2.14.*
+  - uwtools 2.16.*

--- a/src/envs/data.yaml
+++ b/src/envs/data.yaml
@@ -12,7 +12,7 @@ dependencies:
   - setuptools 81.0.*
   - types-pyyaml
   - ufs2arco 0.19.*
-  - uwtools 2.14.*
+  - uwtools 2.16.*
   - xarray 2026.2.*
   - xesmf 0.9.2
   - pip:

--- a/src/envs/visualization.yaml
+++ b/src/envs/visualization.yaml
@@ -8,7 +8,7 @@ dependencies:
   - numpy 2.2.6
   - pip
   - python 3.13
-  - uwtools 2.14.*
+  - uwtools 2.16.*
   - xarray 2026.2.0
   - pip:
       - eagle-tools==0.8.1

--- a/src/envs/wxvx.yaml
+++ b/src/envs/wxvx.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - pip
   - python 3.13
-  - uwtools 2.14.*
+  - uwtools 2.16.*
   - wxvx >=0.7.2
   - xesmf 0.8.*
   - zarr 2.18.*


### PR DESCRIPTION
## Description:

Fixes #171.

A user reported that, to run training (and presumably inference) across multiple GPU nodes, `anemoi-training` and `anemoi-inference` need to be launched with `srun` on a Slurm system like Ursa. Also, since the batch runscript does some shell-environment setup before running Anemoi, that environment needs to be propagated to the other batch nodes with `--export=ALL`.

As discussed in a recent EAGLE Science meeting, it appears that there's no problem running training and inference this way even when multiple GPUs are not used, as demonstrated by successful runs of the current Nested EAGLE Quickstart and CI configurations.

See inline comments for more details.

## Type of change:

- [x] New feature

## Area(s) affected

- [x] nested_eagle workflow

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary

## Testing / Verification:

Ran the _Quickstart_ pipeline manually on Ursa. CI tests will pass before merge.
