### PR TITLE
Change method for updating envcmds for Ursa, restore set -ex

### DIFF
--- a/src/config/base.yaml
+++ b/src/config/base.yaml
@@ -41,10 +41,7 @@ inference:
       memory: 16G
       rundir: '{{ inference.rundir }}'
       walltime: '00:10:00'
-    envcmds:
-      - source {{ val.conda }}/etc/profile.d/conda.sh
-      - conda activate anemoi
-      - set -e
+    envcmds: !list '{{ val.inference.envcmds }}'
     executable: '{{ app.launcher | default("") }} eagle-tools inference inference.yaml'
   rundir: '{{ app.rundir }}/inference'
 platform: !dict '{{ app.platform }}'
@@ -66,13 +63,7 @@ training:
       memory: 128G
       rundir: '{{ training.rundir }}'
       walltime: '01:00:00'
-    envcmds:
-      - source {{ val.conda }}/etc/profile.d/conda.sh
-      - conda activate anemoi
-      - export MLFLOW_ALLOW_FILE_STORE=true
-      - export SLURM_GPUS_PER_NODE=1
-      - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
-      - set -e
+    envcmds: !list '{{ val.training.envcmds }}'
     executable: '{{ app.launcher | default("") }} anemoi-training train --config-name=training'
   remove:
     # Dot-separated config keys paths to delete from the composed runtime config.
@@ -141,11 +132,24 @@ val:
     rundir: '{{ app.rundir }}/data'
   filenames:
     gfs_target_grid: global_one_degree.nc
+  inference:
+    envcmds:
+      - source {{ val.conda }}/etc/profile.d/conda.sh
+      - conda activate anemoi
+      - set -ex
   levels: [100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
   statsdelta:
     aligned: !timedelta '{{ (val.statsdelta.raw - val.statsdelta.raw % app.time.step).total_seconds() / 3600 }}'
     raw: !timedelta '{{ ((app.time.stop - app.time.start) * 0.8).total_seconds() / 3600 }}'
   step: !int '{{ (app.time.step.total_seconds() / 3600) | int }}'
+  training:
+    envcmds:
+      - source {{ val.conda }}/etc/profile.d/conda.sh
+      - conda activate anemoi
+      - export MLFLOW_ALLOW_FILE_STORE=true
+      - export SLURM_GPUS_PER_NODE=1
+      - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+      - set -ex
   variables:
     analysis:
       # 3D Prognostic
@@ -175,6 +179,11 @@ val:
     rundir: '{{ app.rundir }}/visualization'
   vx:
     rundir: '{{ app.rundir }}/vx'
+  zarrs:
+    envcmds:
+      - source {{ val.conda }}/etc/profile.d/conda.sh
+      - conda activate data
+      - set -ex
 visualization:
   common:
     postwxvx: &postwxvx-common
@@ -374,10 +383,7 @@ zarrs:
         partition: '{{ app.partitions.netaccess }}'
         rundir: '{{ val.data.rundir }}'
         walltime: '00:10:00'
-      envcmds:
-        - source {{ val.conda }}/etc/profile.d/conda.sh
-        - conda activate data
-        - set -e
+      envcmds: !list '{{ val.zarrs.envcmds }}'
       mpiargs: []
       mpicmd: '{{ "srun" if app.platform.scheduler == "slurm" else "mpiexec" }}'
   gfs:

--- a/src/config/ursa.yaml
+++ b/src/config/ursa.yaml
@@ -17,18 +17,18 @@ app:
     scheduler: slurm
 inference:
   execution:
-    envcmds: !extend
-      - source /etc/profile.d/profile-slurm.sh
+    envcmds: !list '{{ val.slurm_script + val.inference.envcmds  }}'
 training:
   execution:
-    envcmds: !extend
-      - source /etc/profile.d/profile-slurm.sh
+    envcmds: !list '{{ val.slurm_script + val.training.envcmds }}'
+val:
+  slurm_script:
+    - source /etc/profile.d/profile-slurm.sh
 zarrs:
   common:
     execution:
       batchargs:
         --mem-per-cpu: 3G
-      envcmds: !extend
-        - source /etc/profile.d/profile-slurm.sh
+      envcmds: !list '{{ val.slurm_script + val.zarrs.envcmds }}'
       mpiargs:
         - "--export=ALL"


### PR DESCRIPTION
## Description:

Instead of the `uwtools` `!extend` tag, use standard Jinja2 techniques to factor out the environment command to activate Slurm commands on Ursa; put this command at the head, rather than the tail, of the `envcmds` list; and to restore the `set -ex` command to `inference`, `training`, and `zarrs` driver runscripts.

Fixes #180.

## Type of change:

- [x] Refactor / cleanup

## Area(s) affected

- [x] Config (YAML)

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary

## Testing / Verification:

Manual _Quickstart_ pipeline run on Ursa, and CI tests will pass before merge.
