### PR TITLE
Add note to Quickstart about benign error messages from pip

### DIFF
--- a/docs/user_guide/quickstart.rst
+++ b/docs/user_guide/quickstart.rst
@@ -34,6 +34,16 @@ Building and Running :term:`EAGLE`
    create the same environments but also install additional code-quality tools for formatting, linting, shellchecking, 
    typechecking, unit testing, and :term:`YAML` linting.
 
+.. note::
+
+   EAGLE virtual environments are built using both conda and pip packages. If you examine the output from the ``make env`` command above, you may see messages like the following, from pip:
+
+   .. code-block:: text
+
+      ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
+
+   This will be followed by a report of packages pip believes are not installed or are installed with incompatible versions. These messages are due to fundamental differences in how conda and pip operate, and are generally safe to ignore. But please open an :ref:`Issue <Issues>` if you later encounter problems you believe are related to package versions.
+
 #. Create the EAGLE YAML config
 
    .. code-block:: bash

--- a/src/setup
+++ b/src/setup
@@ -118,7 +118,7 @@ prep_env() {
   )
   cat <<EOF
 
-Note: Apparent pip errors about not installed or incompatible packages are generally safe to ignore.
+Note: Apparent pip errors, if any, about not installed or incompatible packages are generally safe to ignore.
 
 EOF
   install_devpkgs_maybe $name

--- a/src/setup
+++ b/src/setup
@@ -116,6 +116,11 @@ prep_env() {
       mamba env create ${args[@]}
     fi
   )
+  cat <<EOF
+
+Note: Apparent pip errors about not installed or incompatible packages are generally safe to ignore.
+
+EOF
   install_devpkgs_maybe $name
   # When runtime virtual environments are activated, set XDG_CACHE_HOME so that pip caches package
   # files in the runtime area, rather than in the user's home directory, which might impact their


### PR DESCRIPTION
## Description:

Add a note to the Quickstart documentation about benign "error" messages from pip relating to package versions.

Also emit a similar note the `setup` script.

Resolves #187.

## Type of change:

- [x] Documentation

## Area(s) affected

- [ ] Other: Quickstart

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary

## Testing / Verification:

CI tests will pass before merge. Also built successfully on Ursa with these changes.