### PR TITLE
Pin matplotlib <3.9

### DIFF
--- a/src/envs/anemoi.yaml
+++ b/src/envs/anemoi.yaml
@@ -4,7 +4,7 @@ channels:
   - ufs-community
 dependencies:
   - flash-attn 2.8.*
-  - matplotlib <3.9
+  - matplotlib >=3.7.1,<3.9 # low bound per anemoi-training; high bound per matplotlib Issue 28317
   - mpi4py 4.1.*
   - numpy 2.2.6.*
   - pip

--- a/src/envs/anemoi.yaml
+++ b/src/envs/anemoi.yaml
@@ -4,6 +4,7 @@ channels:
   - ufs-community
 dependencies:
   - flash-attn 2.8.*
+  - matplotlib <3.9
   - mpi4py 4.1.*
   - numpy 2.2.6.*
   - pip

--- a/src/envs/anemoi.yaml
+++ b/src/envs/anemoi.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:anchors rule:line-length
+
 channels:
   - nodefaults
   - conda-forge


### PR DESCRIPTION
## Description:

We have lately seen the following error from `anemoi-training`:

```
Error in call to target 'anemoi.training.utils.custom_colormaps.MatplotlibColormap':
AttributeError("module 'matplotlib.cm' has no attribute 'get_cmap'")
```

- This attribute apparently was [removed in `matplotlib` 3.9](https://github.com/matplotlib/matplotlib/issues/28317).
- `anemoi-training` [pins to `matplotlib` >=3.7.1](https://github.com/ecmwf/anemoi-core/blob/main/training/pyproject.toml#L77) and apparently calls `get_cmap`.
- `eagle-tools` (also installed into the EAGLE `anemoi` environment) requires `matplotlib`, but at [no specific version](https://github.com/NOAA-PSL/eagle-tools/blob/main/pyproject.toml#L31).
- My most recent EAGLE build pulled in v3.11, which does not provide `get_cmap`.

This PR pins `matplotlib` to the range meeting these constraints.

Fixes #189.

## Type of change:

- [x] Bug fix

## Area(s) affected

- [x] Other: Software environment

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary

## Testing / Verification:

Manual run of Quickstart steps on Ursa. CI checks will pass before commit.
