### PR TITLE
Environment and CI updates

### DIFF
--- a/.github/scripts/fsclean
+++ b/.github/scripts/fsclean
@@ -2,7 +2,7 @@
 
 # shellcheck disable=2068,2086
 
-GIGSREQD=57
+GIGSREQD=47
 
 gigsfree() { df . -BG --output=avail | tail -n1 | sed 's/[^0-9]//g'; }
 msg() { echo $GIGSREQD GB NEEDED, $1 GB AVAILABLE: $2; }

--- a/envs/anemoi.yaml
+++ b/envs/anemoi.yaml
@@ -12,6 +12,8 @@ dependencies:
   - pip
   - python 3.12
   - setuptools 81.0.*
+  - torch 2.10.*
+  - triton 3.6.*
   - uwtools 2.16.*
   - pip:
       - anemoi-inference==0.10.*

--- a/envs/anemoi.yaml
+++ b/envs/anemoi.yaml
@@ -19,4 +19,5 @@ dependencies:
       - anemoi-inference==0.10.*
       - anemoi-models==0.13.*
       - anemoi-training==0.10.*
+      - anemoi-transform==0.1.29
       - eagle-tools==0.8.1

--- a/envs/anemoi.yaml
+++ b/envs/anemoi.yaml
@@ -11,8 +11,8 @@ dependencies:
   - numpy 2.2.6.*
   - pip
   - python 3.12
+  - pytorch 2.10.*
   - setuptools 81.0.*
-  - torch 2.10.*
   - triton 3.6.*
   - uwtools 2.16.*
   - pip:

--- a/envs/data.yaml
+++ b/envs/data.yaml
@@ -16,8 +16,6 @@ dependencies:
   - xarray 2026.2.*
   - xesmf 0.9.2.*
   - pip:
-      # Keep pip from upgrading NumPy past the ufs2arco/numba bounds.
-      - numpy<2.3
       - anemoi-datasets==0.5.*
       - anemoi-graphs==0.9.*
       - anemoi-transform==0.1.29

--- a/envs/data.yaml
+++ b/envs/data.yaml
@@ -3,18 +3,18 @@ channels:
   - conda-forge
   - ufs-community
 dependencies:
-  - cf-xarray 0.10.11
+  - cf-xarray 0.10.11.*
   - impi_rt 2021.13.*
   - mpi4py 4.1.*
-  - numpy 1.26.4
-  - pandas 2.3.3
+  - numpy 2.2.6.*
+  - pandas 2.3.3.*
   - pip
   - setuptools 81.0.*
   - types-pyyaml
   - ufs2arco 0.19.*
   - uwtools 2.16.*
   - xarray 2026.2.*
-  - xesmf 0.9.2
+  - xesmf 0.9.2.*
   - pip:
       # Keep pip from upgrading NumPy past the ufs2arco/numba bounds.
       - numpy<2.3

--- a/envs/visualization.yaml
+++ b/envs/visualization.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - cartopy 0.25.*
   - matplotlib 3.10.*
-  - numpy 2.2.6
+  - numpy 2.2.6.*
   - pip
   - python 3.13
   - uwtools 2.16.*

--- a/envs/visualization.yaml
+++ b/envs/visualization.yaml
@@ -6,6 +6,7 @@ dependencies:
   - cartopy 0.25.*
   - matplotlib 3.10.*
   - numpy 2.2.6.*
+  - pandas 2.3.*
   - pip
   - python 3.13
   - uwtools 2.16.*

--- a/envs/wxvx.yaml
+++ b/envs/wxvx.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - pip
   - python 3.13
+  - requests 2.34.*
   - uwtools 2.16.*
   - wxvx >=0.7.2
   - xesmf 0.8.*

--- a/envs/wxvx.yaml
+++ b/envs/wxvx.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python 3.13
   - requests 2.34.*
   - uwtools 2.16.*
-  - wxvx >=0.7.2
+  - wxvx >=0.7.3
   - xesmf 0.8.*
   - zarr 2.18.*
   - pip:

--- a/setup
+++ b/setup
@@ -113,6 +113,7 @@ prep_env() {
       mamba env update ${args[@]} | { grep --line-buffered -v "Requirement already satisfied" || true; }
     else
       msg Creating environment: $name
+      export PIP_VERBOSE=1
       mamba env create ${args[@]}
     fi
   )


### PR DESCRIPTION
- Install `numpy` `2.2.6` in `data` environment to satisfy both `ufs2arco` direct (`<2.3`) and `anemoi` transitive (`>2.0.0`) version constraints.
- Export `PIP_VERBOSE=1` when creating conda environments with PyPI packages to see pip output.
- Install some conda packages at specific versions to satisfy PyPI package constraints, to avoid pip uninstalling conda packages and then re-installing different versions.
- Install `wxvx` `0.7.3`, which loosens its constraint on the `requests` package.
- Lower free-space requirement in `fsclean` script for the code-quality-checks workflow, possible due to space-freeing improvements on the target branch.
