### PR TITLE
Change pytest tmp_path base directory for code-quality workflow

### DIFF
--- a/.github/workflows/cqc.yml
+++ b/.github/workflows/cqc.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Python Typechecker
         run: make typecheck
       - name: Run Python Unit Tests
-        run: make unittest
+        run: PYTEST_DEBUG_TEMPROOT=$GITHUB_WORKSPACE make unittest
       - name: Run Shell Checker
         run: make shellcheck
       - name: Run YAML Linter

--- a/.github/workflows/cqc.yml
+++ b/.github/workflows/cqc.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Python Typechecker
         run: make typecheck
       - name: Run Python Unit Tests
-        run: PYTEST_DEBUG_TEMPROOT=$GITHUB_WORKSPACE make unittest
+        run: make unittest
       - name: Run Shell Checker
         run: make shellcheck
       - name: Run YAML Linter

--- a/setup
+++ b/setup
@@ -202,7 +202,8 @@ prep_env_data() {
   local name
   name=data
   prep_env $name
-  # Add logic to the [de]activation scripts to silence a run-time complaint:
+  # Add logic to the [de]activation scripts to silence run-time complaints and avoid
+  # segfaults when importing mpi4py in environments without InfiniBand hardware:
   (
     env_activate $name
     dir_activate=$CONDA_PREFIX/etc/conda/activate.d
@@ -213,6 +214,10 @@ if [[ -v FI_PSM3_UUID ]]; then
   export EAGLE_OLD_FI_PSM3_UUID=\$FI_PSM3_UUID
 fi
 export FI_PSM3_UUID=eagle
+if [[ -v FI_PROVIDER ]]; then
+  export EAGLE_OLD_FI_PROVIDER=\$FI_PROVIDER
+fi
+export FI_PROVIDER=tcp
 EOF
     dir_deactivate=$CONDA_PREFIX/etc/conda/deactivate.d
     mkdir -pv $dir_deactivate
@@ -222,6 +227,11 @@ unset FI_PSM3_UUID
 if [[ -v EAGLE_OLD_FI_PSM3_UUID ]]; then
   export FI_PSM3_UUID=\$EAGLE_OLD_FI_PSM3_UUID
   unset EAGLE_OLD_FI_PSM3_UUID
+fi
+unset FI_PROVIDER
+if [[ -v EAGLE_OLD_FI_PROVIDER ]]; then
+  export FI_PROVIDER=\$EAGLE_OLD_FI_PROVIDER
+  unset EAGLE_OLD_FI_PROVIDER
 fi
 EOF
   )


### PR DESCRIPTION
## Description:

Set `FI_PROVIDER=tcp` upon activation of the `data` environment, and unset (or reset, if previously set in the shell) upon deactivation. Fixes #212. Hopefully: The code-quality-checks Actions workflow passed 20 times in a row.

## Type of change:

- [x] CI/CD or tooling

## Area(s) affected

- [x] Other: CI tests

## Commit Requirements:

- [x] This PR addresses a relevant NOAA-EPIC/EAGLE issue (if not, create an issue); a person responsible for submitting the update has been assigned to the issue (link issue)
- [x] Fill out all sections of this template.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the system documentation if necessary
- [x] I checked whether this PR requires subcomponent PRs and completed the subcomponent checklist below

## Testing / Verification:

- [x] I ran and/or verified the changes (or provided a test plan)

CI tests will pass before merge.

## Runtime Environment:

GitHub Actions.
